### PR TITLE
 update mongoengine version 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     name='pycoSHARK',
     version=pycoshark.__version__,
     description='Basic MongoDB Models for smartSHARK.',
-    install_requires=['mongoengine==0.23.1', 'pymongo==3.12.2', 'python-dateutil', 'textdistance', 'networkx'],
+    install_requires=['mongoengine>=0.23.1', 'pymongo==3.12.2', 'python-dateutil', 'textdistance', 'networkx'],
     author='ftrautsch',
     author_email='fabian.trautsch@uni-goettingen.de',
     url='https://github.com/smartshark/pycoSHARK',


### PR DESCRIPTION
The current stable version of mongoengine is 0.27.0. This version is tested on other plugins and it's working as expected.